### PR TITLE
Set backend to s3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  backend "kubernetes" {}
+  backend "s3" {}
 }
 
 provider "scaleway" {


### PR DESCRIPTION
Swap backend type to `s3` so we can use Scaleway storage for state.