### PR TITLE
Update for scaleway state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,11 @@
 terraform {
-  backend "gcs" {}
+  backend "s3" {}
   required_version = "> 1.0.0"
 }
 
 provider "scaleway" {
-  zone       = var.scaleway_zone
-  region     = var.scaleway_region
-  project_id = var.scaleway_project_id
+  zone            = var.scaleway_zone
+  region          = var.scaleway_region
+  project_id      = var.scaleway_project_id
+  organization_id = var.scaleway_organization_id
 }

--- a/vars.tf
+++ b/vars.tf
@@ -7,6 +7,12 @@ variable "scaleway_project_id" {
   type        = string
 }
 
+variable "scaleway_organization_id" {
+  description = "Scaleway organisation ID"
+  type        = string
+  default     = "9c8b8986-7213-4cbc-b531-fd010fece93e"
+}
+
 variable "scaleway_region" {
   description = "Scaleway region ID"
   type        = string


### PR DESCRIPTION
Move to `s3` state so we can use Scaleway object storage.